### PR TITLE
fix windows build by not building canifconfig

### DIFF
--- a/cangaroo.pro
+++ b/cangaroo.pro
@@ -1,5 +1,5 @@
-SUBDIRS += src \
-    canifconfig
+SUBDIRS += src
+!win32:SUBDIRS += canifconfig
 TEMPLATE = subdirs 
 CONFIG += ordered warn_on qt debug_and_release
 CONFIG += c++11


### PR DESCRIPTION
The Windows build is failed by indicating "Project ERROR: libnl-3.0 development package not found". It looks to me that `canifconfig` is not buildable on Windows since there is no SocketCAN interface on Windows. So this two-line change will skip `canifconfig` on Windows and fix the issue #7.

I am not sure about macOS (Mac OS X), though my brief googling hasn't found out a macOS implementation of SocketCAN as well. If that's true, we may disable `canifconfig` for Mac as well, though more changes might be needed for a successful Mac build.

This patch has been tested on Windows 10 and Ubuntu 14.04.4 LTS.