### PR TITLE
api/candle : WaitForMultipleObjects returns >= 0

### DIFF
--- a/src/driver/CandleApiDriver/api/candle.c
+++ b/src/driver/CandleApiDriver/api/candle.c
@@ -516,7 +516,7 @@ bool __stdcall DLL candle_frame_read(candle_handle hdev, candle_frame_t *frame, 
         return false;
     }
 
-    if ( (wait_result < WAIT_OBJECT_0) || (wait_result >= WAIT_OBJECT_0 + CANDLE_URB_COUNT) ) {
+    if (wait_result >= WAIT_OBJECT_0 + CANDLE_URB_COUNT) {
         dev->last_error = CANDLE_ERR_READ_WAIT;
         return false;
     }


### PR DESCRIPTION
minor compilation fix.

MS docs ( https://docs.microsoft.com/en-us/windows/desktop/api/synchapi/nf-synchapi-waitformultipleobjects#return-value ) state that WAIT_OBJECT_0 is "defined as 0", so there is no point
in checking for "returnvalue < 0".

This commit silences a compiler warning with gcc.