### PR TITLE
fix build issue on ubuntu 22.04, kernel 6.2.0

### DIFF
--- a/src/driver/SocketCanDriver/SocketCanInterface.cpp
+++ b/src/driver/SocketCanDriver/SocketCanInterface.cpp
@@ -40,6 +40,7 @@
 #include <linux/can.h>
 #include <linux/can/raw.h>
 #include <linux/can/netlink.h>
+#include <linux/sockios.h>
 #include <netlink/version.h>
 #include <netlink/route/link.h>
 #include <netlink/route/link/can.h>


### PR DESCRIPTION
with kernel 6.2.0: 

```
driver/SocketCanDriver/SocketCanInterface.cpp:428:28: error: ‘SIOCGSTAMPNS’ was not declared in this scope; did you mean ‘SIOCGSTAMP_OLD’?
  428 |             if (ioctl(_fd, SIOCGSTAMPNS, &ts_rcv) == 0) {
      |                            ^~~~~~~~~~~~
      |                            SIOCGSTAMP_OLD
driver/SocketCanDriver/SocketCanInterface.cpp:436:24: error: ‘SIOCGSTAMP’ was not declared in this scope; did you mean ‘SIOCGRARP’?
  436 |             ioctl(_fd, SIOCGSTAMP, &tv_rcv);
      |                        ^~~~~~~~~~
      |                        SIOCGRARP
driver/SocketCanDriver/SocketCanInterface.cpp: In member function ‘virtual void SocketCanInterface::sendMessage(const CanMessage&)’:
driver/SocketCanDriver/SocketCanInterface.cpp:396:16: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  396 |         ::write(_fd, &frame, sizeof(struct can_frame));
```